### PR TITLE
add-method-converting-string-to-symbol

### DIFF
--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -43,6 +43,9 @@ module Embulk
 				bq = Google::Cloud::Bigquery.new(project: @task[:project], keyfile: @task[:keyfile])
 				params = @task[:params]
 				rows = bq.query(@task[:sql])
+
+				@task[:columns] = values_to_sym(@task[:columns], 'name')
+
 				rows.each do |row|
 					columns = []
 					@task[:columns].each do |c|
@@ -57,6 +60,13 @@ module Embulk
 				end
 				@page_builder.finish
 				return {}
+			end
+
+			def values_to_sym(hashs, key)
+				hashs.map do |h|
+					h[key] = h[key].to_sym
+					h
+				end
 			end
     end
   end


### PR DESCRIPTION
Related issue https://github.com/narita-takeru/embulk-input-bigquery/issues/1

### remarks

- Although string values of column `task[:columns]` are symbolize before [`yield(task, columns, 1)`](https://github.com/narita-takeru/embulk-input-bigquery/blob/master/lib/embulk/input/bigquery.rb#L37), type of value of column of @task[:columns] becomes string. 
- Therefore, I try to symbolize in the scope of `run` method.
- I am new to Ruby language. So please let me know if my diffs have inappropriate grammar.
