### PR TITLE
add optional configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ in:
   columns:
     - {name: price, type: long}
     - {name: category_id, type: string}
+  max: 2000
 out:
   type: stdout
 ```
@@ -39,3 +40,19 @@ in:
     - {name: month, type: timestamp, format: '%Y-%m', eval: 'require "time"; Time.parse(params["date"]).to_i'}
 ```
 
+## Optional Configuration
+This plugin uses the gem [`google-cloud(Google Cloud Client Library for Ruby)`](https://github.com/GoogleCloudPlatform/google-cloud-ruby) and queries data using [the synchronous method](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L281).
+Therefore some optional configuration items comply with the Google Cloud Client Library.
+
+- [max](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L315) :
+  - default value : **null** and null value is interpreted as [no maximum row count](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L319) in the Google Cloud Client Library.
+- [cache](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L331) :
+  - default value : **null** and null value is interpreted as [true](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L333) in the Google Cloud Client Library.
+- [timeout](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L321) :
+  - default value : **null** and null value is interpreted as [10000](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L315) milliseconds in the Google Cloud Client Library.
+- [dryrun](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L327) :
+  - default value : **null** and null value is interpreted as [false](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L330) in the Google Cloud Client Library.
+- [standard_sql](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L343):
+  - default value : **null** and null value is interpreted as [true](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L351) in the Google Cloud Client Library.
+- [legacy_sql](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L353):
+  - default value : **null** and null value is interpreted as [false](https://github.com/GoogleCloudPlatform/google-cloud-ruby/blob/master/google-cloud-bigquery/lib/google/cloud/bigquery/project.rb#L361) in the Google Cloud Client Library.

--- a/lib/embulk/input/bigquery.rb
+++ b/lib/embulk/input/bigquery.rb
@@ -26,7 +26,15 @@ module Embulk
 					keyfile: config[:keyfile],
 					sql: sql,
 					columns: config[:columns],
-					params: params
+					params: params,
+					option: {
+						max: config[:max],
+						cache: config[:cache],
+						timeout: config[:timeout],
+						dryrun:  config[:dryrun]
+						standard_sql: config[:standard_sql],
+						legacy_sql: config[:legacy_sql]
+					}
 				}
 
 				columns = []
@@ -42,7 +50,8 @@ module Embulk
 			def run
 				bq = Google::Cloud::Bigquery.new(project: @task[:project], keyfile: @task[:keyfile])
 				params = @task[:params]
-				rows = bq.query(@task[:sql])
+				option = keys_to_sym(@task[:option])
+				rows = bq.query(@task[:sql], **option)
 				rows.each do |row|
 					columns = []
 					@task[:columns].each do |c|
@@ -57,6 +66,14 @@ module Embulk
 				end
 				@page_builder.finish
 				return {}
+			end
+
+			def keys_to_sym(hash)
+				ret = {}
+				hash.each do |key, value|
+					ret[key.to_sym] = value
+				end
+				ret
 			end
     end
   end


### PR DESCRIPTION
Related issue https://github.com/narita-takeru/embulk-input-bigquery/issues/3

### remarks

- In `run` method scope, type of all keys of the hash [`@task[: option]`](https://github.com/YujiKoyano/embulk-input-bigquery/blob/feature/correspond-option-parameter/lib/embulk/input/bigquery.rb#L53) become string, although the type of all keys of the hash [option](https://github.com/YujiKoyano/embulk-input-bigquery/blob/feature/correspond-option-parameter/lib/embulk/input/bigquery.rb#L30) is symbol.
- Therefore, I added [keys_to_sym](https://github.com/YujiKoyano/embulk-input-bigquery/blob/feature/correspond-option-parameter/lib/embulk/input/bigquery.rb#L71) method for converting string to hash. 
